### PR TITLE
chore(package): adds node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "ts-jest": "^23.0.0",
     "typescript": "^3.0.0",
     "vue-template-compiler": "^2.5.17"
+  },
+  "engines": {
+    "node": "8.9.4"
   }
 }


### PR DESCRIPTION
Pushing to heroku failed and it was one of the suggested resolutions